### PR TITLE
Make read response FIFO configurable

### DIFF
--- a/src/AXI4_Master.bsv
+++ b/src/AXI4_Master.bsv
@@ -66,7 +66,7 @@ module mkAXI4_Master_Rd#(Integer bufferIn, Integer bufferOut, Bool bram)(AXI4_Ma
     else
         in <- mkSizedFIFOF(bufferIn);
 
-    FIFOF#(AXI4_Read_Rs#(datawidth, id_width, user_width)) out <- mkSizedFIFOF(bufferOut);
+    FIFOF#(AXI4_Read_Rs#(datawidth, id_width, user_width)) out = ?;
     if(bufferOut == 0)
         out <- mkBypassFIFOF();
     else if(bufferOut == 1)


### PR DESCRIPTION
Let read response FIFO in AXI4 Master be configurable as Bypass/Pipeline-FIFO like all other FIFOs as well.