### PR TITLE
Fix installation git pull URL + AXI4 master comment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ Have the Bluespec compiler installed.
 
 1. Clone the repo
 ```sh
-git clone github.com/esa-tu-darmstadt/BlueAXI.git
+git clone https://github.com/esa-tu-darmstadt/BlueAXI.git
 ```
 3. Import `BlueAXI` or a part of the packet in your Bluespec packet:
 ```

--- a/src/AXI4_Master.bsv
+++ b/src/AXI4_Master.bsv
@@ -149,7 +149,7 @@ endmodule
 
 /*
 ========================
-    AXI 4 Lite Master Write
+    AXI 4 Master Write
 ========================
 */
 (* always_ready, always_enabled *)


### PR DESCRIPTION
This PR fixes two strings. 
1. The previous `git pull github.com/esa-tu-darmstadt/BlueAXI.git` command in the installation part of the README.md did not resolve the github URL correctly. Adding https:// should be what is intended here.
2. The header comment of the `AXI 4 Master Read` module in  `AXI4_Master.bsv` stated that it was AXI Lite, which it should not be